### PR TITLE
두번째 피드백 적용

### DIFF
--- a/src/main/java/GameController.java
+++ b/src/main/java/GameController.java
@@ -42,7 +42,7 @@ public class GameController {
 
     private void needMoreCard(Player player) {
         while (player.needMoreCard(getAnswerForNeedMoreCard(player), deck)) {
-            if (player.checkBurst()) {
+            if (player.isBurst()) {
                 OutputView.printBurst(player);
                 break;
             }

--- a/src/main/java/domains/result/GameResult.java
+++ b/src/main/java/domains/result/GameResult.java
@@ -37,7 +37,7 @@ public class GameResult {
     }
 
     public WinOrDrawOrLose checkWinOrLose(Player player, Dealer dealer) {
-        if (dealer.checkBurst() && !player.isBurst()) {
+        if (dealer.isBurst() && !player.isBurst()) {
             return WinOrDrawOrLose.WIN;
         }
         if (player.score() > dealer.score()) {

--- a/src/main/java/domains/result/GameResult.java
+++ b/src/main/java/domains/result/GameResult.java
@@ -21,7 +21,7 @@ public class GameResult {
             if (checkBurstPlayer(player)) {
                 continue;
             }
-            playerResult.put(player, checkWinOrLose(player, dealer));
+            playerResult.put(player, player.checkKindOfGameResult(dealer));
         }
         calculateDealerResult();
     }
@@ -32,19 +32,6 @@ public class GameResult {
             return true;
         }
         return false;
-    }
-
-    public KindOfGameResult checkWinOrLose(Player player, Dealer dealer) {
-        if (dealer.isBurst() && !player.isBurst()) {
-            return KindOfGameResult.WIN;
-        }
-        if (player.score() > dealer.score()) {
-            return KindOfGameResult.WIN;
-        }
-        if (player.score() < dealer.score()) {
-            return KindOfGameResult.LOSE;
-        }
-        return KindOfGameResult.DRAW;
     }
 
     public KindOfGameResult getWinOrLose(Player player) {

--- a/src/main/java/domains/result/GameResult.java
+++ b/src/main/java/domains/result/GameResult.java
@@ -10,12 +10,10 @@ import java.util.Map;
 public class GameResult {
     private Map<Player, WinOrDrawOrLose> playerResult;
     private Map<WinOrDrawOrLose, Integer> gameResult;
-    private Map<WinOrDrawOrLose, Integer> dealerResult;
 
     public GameResult() {
         this.playerResult = new HashMap<>();
         this.gameResult = new HashMap<>();
-        this.dealerResult = new HashMap<>();
     }
 
     public void create(Players players, Dealer dealer) {
@@ -61,17 +59,13 @@ public class GameResult {
         for (WinOrDrawOrLose result : playerResult.values()) {
             gameResult.put(result, gameResult.get(result) + 1);
         }
-
-        dealerResult.put(WinOrDrawOrLose.WIN, gameResult.get(WinOrDrawOrLose.LOSE));
-        dealerResult.put(WinOrDrawOrLose.DRAW, gameResult.get(WinOrDrawOrLose.DRAW));
-        dealerResult.put(WinOrDrawOrLose.LOSE, gameResult.get(WinOrDrawOrLose.WIN));
     }
 
     public Map<Player, WinOrDrawOrLose> getPlayerResult() {
         return playerResult;
     }
 
-    public Map<WinOrDrawOrLose, Integer> getDealerResult() {
-        return dealerResult;
+    public Map<WinOrDrawOrLose, Integer> getGameResult() {
+        return gameResult;
     }
 }

--- a/src/main/java/domains/result/GameResult.java
+++ b/src/main/java/domains/result/GameResult.java
@@ -8,8 +8,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class GameResult {
-    private Map<Player, WinOrDrawOrLose> playerResult;
-    private Map<WinOrDrawOrLose, Integer> gameResult;
+    private Map<Player, KindOfGameResult> playerResult;
+    private Map<KindOfGameResult, Integer> gameResult;
 
     public GameResult() {
         this.playerResult = new HashMap<>();
@@ -28,44 +28,44 @@ public class GameResult {
 
     private boolean checkBurstPlayer(Player player) {
         if (player.isBurst()) {
-            playerResult.put(player, WinOrDrawOrLose.LOSE);
+            playerResult.put(player, KindOfGameResult.LOSE);
             return true;
         }
         return false;
     }
 
-    public WinOrDrawOrLose checkWinOrLose(Player player, Dealer dealer) {
+    public KindOfGameResult checkWinOrLose(Player player, Dealer dealer) {
         if (dealer.isBurst() && !player.isBurst()) {
-            return WinOrDrawOrLose.WIN;
+            return KindOfGameResult.WIN;
         }
         if (player.score() > dealer.score()) {
-            return WinOrDrawOrLose.WIN;
+            return KindOfGameResult.WIN;
         }
         if (player.score() < dealer.score()) {
-            return WinOrDrawOrLose.LOSE;
+            return KindOfGameResult.LOSE;
         }
-        return WinOrDrawOrLose.DRAW;
+        return KindOfGameResult.DRAW;
     }
 
-    public WinOrDrawOrLose getWinOrLose(Player player) {
+    public KindOfGameResult getWinOrLose(Player player) {
         return playerResult.get(player);
     }
 
     private void calculateDealerResult() {
-        for (WinOrDrawOrLose winOrDrawOrLose : WinOrDrawOrLose.values()) {
-            gameResult.put(winOrDrawOrLose, 0);
+        for (KindOfGameResult kindOfGameResult : KindOfGameResult.values()) {
+            gameResult.put(kindOfGameResult, 0);
         }
 
-        for (WinOrDrawOrLose result : playerResult.values()) {
+        for (KindOfGameResult result : playerResult.values()) {
             gameResult.put(result, gameResult.get(result) + 1);
         }
     }
 
-    public Map<Player, WinOrDrawOrLose> getPlayerResult() {
+    public Map<Player, KindOfGameResult> getPlayerResult() {
         return playerResult;
     }
 
-    public Map<WinOrDrawOrLose, Integer> getGameResult() {
+    public Map<KindOfGameResult, Integer> getGameResult() {
         return gameResult;
     }
 }

--- a/src/main/java/domains/result/KindOfGameResult.java
+++ b/src/main/java/domains/result/KindOfGameResult.java
@@ -1,11 +1,11 @@
 package domains.result;
 
-public enum WinOrDrawOrLose {
+public enum KindOfGameResult {
     WIN("승"), LOSE("패"), DRAW("무");
 
     private String winOrDrawOrLose;
 
-    WinOrDrawOrLose(String winOrDrawOrLose) {
+    KindOfGameResult(String winOrDrawOrLose) {
         this.winOrDrawOrLose = winOrDrawOrLose;
     }
 

--- a/src/main/java/domains/user/Dealer.java
+++ b/src/main/java/domains/user/Dealer.java
@@ -18,5 +18,8 @@ public class Dealer extends User {
         if (this.hands.score() <= DEALER_HIT_POINT) {
             this.hands.draw(deck);
         }
+        if (hands.isBurst()) {
+            this.burst = true;
+        }
     }
 }

--- a/src/main/java/domains/user/Hands.java
+++ b/src/main/java/domains/user/Hands.java
@@ -48,10 +48,7 @@ public class Hands {
     }
 
     private boolean checkAce(Card card, boolean hasAce) {
-        if (card.isAce()) {
-            return true;
-        }
-        return hasAce;
+        return hasAce || card.isAce();
     }
 
     public boolean isBurst() {

--- a/src/main/java/domains/user/Player.java
+++ b/src/main/java/domains/user/Player.java
@@ -51,5 +51,8 @@ public class Player extends User {
     @Override
     public void hit(Deck deck) {
         hands.draw(deck);
+        if (hands.isBurst()) {
+            this.burst = true;
+        }
     }
 }

--- a/src/main/java/domains/user/Player.java
+++ b/src/main/java/domains/user/Player.java
@@ -1,6 +1,7 @@
 package domains.user;
 
 import domains.card.Deck;
+import domains.result.KindOfGameResult;
 
 import java.util.Objects;
 
@@ -42,6 +43,19 @@ public class Player extends User {
             return;
         }
         throw new InvalidPlayerException(InvalidPlayerException.INVALID_INPUT);
+    }
+
+    public KindOfGameResult checkKindOfGameResult(Dealer dealer) {
+        if (dealer.isBurst() && !this.isBurst()) {
+            return KindOfGameResult.WIN;
+        }
+        if (this.score() > dealer.score()) {
+            return KindOfGameResult.WIN;
+        }
+        if (this.score() < dealer.score()) {
+            return KindOfGameResult.LOSE;
+        }
+        return KindOfGameResult.DRAW;
     }
 
     public String getName() {

--- a/src/main/java/domains/user/User.java
+++ b/src/main/java/domains/user/User.java
@@ -8,13 +8,6 @@ public abstract class User {
 
     abstract void hit(Deck deck);
 
-    public boolean checkBurst() {
-        if (hands.isBurst()) {
-            this.burst = true;
-        }
-        return this.burst;
-    }
-
     public int handSize() {
         return hands.size();
     }

--- a/src/main/java/view/OutputView.java
+++ b/src/main/java/view/OutputView.java
@@ -1,7 +1,7 @@
 package view;
 
 import domains.result.GameResult;
-import domains.result.WinOrDrawOrLose;
+import domains.result.KindOfGameResult;
 import domains.user.Dealer;
 import domains.user.Player;
 import domains.user.Players;
@@ -53,10 +53,10 @@ public class OutputView {
 
     public static void printGameResult(GameResult gameResult) {
         System.out.println("딜러: "
-                + gameResult.getGameResult().get(WinOrDrawOrLose.LOSE) + WinOrDrawOrLose.WIN.getWinOrDrawOrLose()
-                + gameResult.getGameResult().get(WinOrDrawOrLose.DRAW) + WinOrDrawOrLose.DRAW.getWinOrDrawOrLose()
-                + gameResult.getGameResult().get(WinOrDrawOrLose.WIN) + WinOrDrawOrLose.LOSE.getWinOrDrawOrLose());
-        Map<Player, WinOrDrawOrLose> result = gameResult.getPlayerResult();
+                + gameResult.getGameResult().get(KindOfGameResult.LOSE) + KindOfGameResult.WIN.getWinOrDrawOrLose()
+                + gameResult.getGameResult().get(KindOfGameResult.DRAW) + KindOfGameResult.DRAW.getWinOrDrawOrLose()
+                + gameResult.getGameResult().get(KindOfGameResult.WIN) + KindOfGameResult.LOSE.getWinOrDrawOrLose());
+        Map<Player, KindOfGameResult> result = gameResult.getPlayerResult();
         for (Player player : result.keySet()) {
             System.out.println(player.getName() + ": " + result.get(player).getWinOrDrawOrLose());
         }

--- a/src/main/java/view/OutputView.java
+++ b/src/main/java/view/OutputView.java
@@ -53,9 +53,9 @@ public class OutputView {
 
     public static void printGameResult(GameResult gameResult) {
         System.out.println("딜러: "
-                + gameResult.getDealerResult().get(WinOrDrawOrLose.WIN) + WinOrDrawOrLose.WIN.getWinOrDrawOrLose()
-                + gameResult.getDealerResult().get(WinOrDrawOrLose.DRAW) + WinOrDrawOrLose.DRAW.getWinOrDrawOrLose()
-                + gameResult.getDealerResult().get(WinOrDrawOrLose.LOSE) + WinOrDrawOrLose.LOSE.getWinOrDrawOrLose());
+                + gameResult.getGameResult().get(WinOrDrawOrLose.LOSE) + WinOrDrawOrLose.WIN.getWinOrDrawOrLose()
+                + gameResult.getGameResult().get(WinOrDrawOrLose.DRAW) + WinOrDrawOrLose.DRAW.getWinOrDrawOrLose()
+                + gameResult.getGameResult().get(WinOrDrawOrLose.WIN) + WinOrDrawOrLose.LOSE.getWinOrDrawOrLose());
         Map<Player, WinOrDrawOrLose> result = gameResult.getPlayerResult();
         for (Player player : result.keySet()) {
             System.out.println(player.getName() + ": " + result.get(player).getWinOrDrawOrLose());

--- a/src/test/java/domains/result/GameResultTest.java
+++ b/src/test/java/domains/result/GameResultTest.java
@@ -1,14 +1,20 @@
 package domains.result;
 
+import domains.card.Card;
+import domains.card.Symbol;
+import domains.card.Type;
 import domains.user.Dealer;
+import domains.user.Hands;
 import domains.user.Player;
 import domains.user.Players;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Iterator;
+import java.util.*;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,7 +36,28 @@ public class GameResultTest {
         Player ddoring = iterator.next();
         Player smallBear = iterator.next();
 
-        assertThat(gameResult.getWinOrLose(ddoring)).isEqualTo(WinOrDrawOrLose.WIN);
-        assertThat(gameResult.getWinOrLose(smallBear)).isEqualTo(WinOrDrawOrLose.DRAW);
+        assertThat(gameResult.getWinOrLose(ddoring)).isEqualTo(KindOfGameResult.WIN);
+        assertThat(gameResult.getWinOrLose(smallBear)).isEqualTo(KindOfGameResult.DRAW);
+    }
+
+    static Stream<Arguments> gameData() {
+        Card ace = new Card(Symbol.ACE, Type.CLUB);
+        Card king = new Card(Symbol.KING, Type.HEART);
+        Card four = new Card(Symbol.FOUR, Type.DIAMOND);
+
+        Player ddoring = new Player("또링", new Hands(Arrays.asList(ace, king)));
+        Player smallBear = new Player("작은곰", new Hands(Arrays.asList(ace, four)));
+        Players players = new Players(new ArrayList<>(Arrays.asList(ddoring, smallBear)));
+
+        Dealer dealer = new Dealer(new Hands(Arrays.asList(ace, four)));
+
+        Map<KindOfGameResult, Integer> dealerResult = new HashMap<>();
+        dealerResult.put(KindOfGameResult.WIN, 0);
+        dealerResult.put(KindOfGameResult.DRAW, 1);
+        dealerResult.put(KindOfGameResult.LOSE, 1);
+
+        return Stream.of(
+                Arguments.of(players, dealer, dealerResult)
+        );
     }
 }

--- a/src/test/java/domains/result/GameResultTest.java
+++ b/src/test/java/domains/result/GameResultTest.java
@@ -1,20 +1,14 @@
 package domains.result;
 
-import domains.card.Card;
-import domains.card.Symbol;
-import domains.card.Type;
 import domains.user.Dealer;
-import domains.user.Hands;
 import domains.user.Player;
 import domains.user.Players;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.*;
-import java.util.stream.Stream;
+import java.util.Iterator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,35 +32,5 @@ public class GameResultTest {
 
         assertThat(gameResult.getWinOrLose(ddoring)).isEqualTo(WinOrDrawOrLose.WIN);
         assertThat(gameResult.getWinOrLose(smallBear)).isEqualTo(WinOrDrawOrLose.DRAW);
-    }
-
-    @DisplayName("딜러의 게임 결과를 확인")
-    @ParameterizedTest
-    @MethodSource("gameData")
-    void getDealerResult_PlayerWin_DealerLose(Players players, Dealer dealer, Map<WinOrDrawOrLose, Integer> dealerResult) {
-        gameResult.create(players, dealer);
-
-        assertThat(gameResult.getDealerResult()).isEqualTo(dealerResult);
-    }
-
-    static Stream<Arguments> gameData() {
-        Card ace = new Card(Symbol.ACE, Type.CLUB);
-        Card king = new Card(Symbol.KING, Type.HEART);
-        Card four = new Card(Symbol.FOUR, Type.DIAMOND);
-
-        Player ddoring = new Player("또링", new Hands(Arrays.asList(ace, king)));
-        Player smallBear = new Player("작은곰", new Hands(Arrays.asList(ace, four)));
-        Players players = new Players(new ArrayList<>(Arrays.asList(ddoring, smallBear)));
-
-        Dealer dealer = new Dealer(new Hands(Arrays.asList(ace, four)));
-
-        Map<WinOrDrawOrLose, Integer> dealerResult = new HashMap<>();
-        dealerResult.put(WinOrDrawOrLose.WIN, 0);
-        dealerResult.put(WinOrDrawOrLose.DRAW, 1);
-        dealerResult.put(WinOrDrawOrLose.LOSE, 1);
-
-        return Stream.of(
-                Arguments.of(players, dealer, dealerResult)
-        );
     }
 }

--- a/src/test/java/domains/user/DealerTest.java
+++ b/src/test/java/domains/user/DealerTest.java
@@ -84,4 +84,26 @@ public class DealerTest {
                 Arguments.of(new ArrayList<>(Arrays.asList(four, seven)))
         );
     }
+
+    @DisplayName("카드를 한 장 더 받았을 때, 버스트가 됐는지 확인")
+    @ParameterizedTest
+    @MethodSource("burstData")
+    void hit_ScoreOver21_BurstIsTrue(List<Card> hands) {
+        Hands hand = new Hands(hands);
+        Dealer dealer = new Dealer(hand);
+
+        dealer.hit(deck);
+
+        assertThat(dealer.isBurst()).isTrue();
+    }
+
+    static Stream<Arguments> burstData() {
+        Card five = new Card(Symbol.FIVE, Type.SPADE);
+        Card seven = new Card(Symbol.SEVEN, Type.HEART);
+        Card ten = new Card(Symbol.TEN, Type.CLUB);
+
+        return Stream.of(
+                Arguments.of(new ArrayList<>(Arrays.asList(five, seven, ten)))
+        );
+    }
 }

--- a/src/test/java/domains/user/PlayerTest.java
+++ b/src/test/java/domains/user/PlayerTest.java
@@ -1,11 +1,21 @@
 package domains.user;
 
+import domains.card.Card;
 import domains.card.Deck;
+import domains.card.Symbol;
+import domains.card.Type;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,5 +43,27 @@ public class PlayerTest {
         assertThatThrownBy(() -> player.needMoreCard(answer, deck))
                 .isInstanceOf(InvalidPlayerException.class)
                 .hasMessage(InvalidPlayerException.INVALID_INPUT);
+    }
+
+    @DisplayName("카드를 한 장 더 받았을 때, 버스트가 됐는지 확인")
+    @ParameterizedTest
+    @MethodSource("burstData")
+    void hit_ScoreOver21_BurstIsTrue(List<Card> hands) {
+        Hands hand = new Hands(hands);
+        Player dealer = new Player("작은곰", hand);
+
+        dealer.hit(deck);
+
+        assertThat(dealer.isBurst()).isTrue();
+    }
+
+    static Stream<Arguments> burstData() {
+        Card five = new Card(Symbol.FIVE, Type.SPADE);
+        Card seven = new Card(Symbol.SEVEN, Type.HEART);
+        Card ten = new Card(Symbol.TEN, Type.CLUB);
+
+        return Stream.of(
+                Arguments.of(new ArrayList<>(Arrays.asList(five, seven, ten)))
+        );
     }
 }

--- a/src/test/java/domains/user/PlayerTest.java
+++ b/src/test/java/domains/user/PlayerTest.java
@@ -66,4 +66,6 @@ public class PlayerTest {
                 Arguments.of(new ArrayList<>(Arrays.asList(five, seven, ten)))
         );
     }
+
+
 }


### PR DESCRIPTION
- User의 burst 상태를 변경하는 로직을 메소드로 분리하지 않고, 상태 변경을 유발하는 메소드에서 구현.
  - checkBurst 메소드를 제거하고, hit 메소드에서 구현.
- GameResult 클래스 내 dealerResult 변수 제거.
  - gameResult와 역할이 중복됨.
- Enum 클래스명 변경.
  - 새로운 상태가 추가되었을 경우, 다시 이름을 바꾸는 것이 되기 때문에, 모든 상태를 포괄할 수 이름으로 변경.
- Player와 Dealer의 점수를 비교하여 Player의 결과를 확인하는 메소드를 GameResult 클래스에서 Player 클래스로 이동.
- Hands 클래스 내 checkAce 메소드의 반환값을 변경하여 메소드의 길이 단축.